### PR TITLE
Misc improvements and fixes

### DIFF
--- a/denops/ddc/sources/ale.ts
+++ b/denops/ddc/sources/ale.ts
@@ -16,7 +16,7 @@ export class Source extends BaseSource {
   ): Promise<number> {
     return denops.call(
       "ale#completion#GetCompletionPositionForDeoplete",
-      context.input
+      context.input,
     ) as Promise<number>;
   }
 
@@ -27,14 +27,14 @@ export class Source extends BaseSource {
       denops.call(
         "ddc#ale#get_completions",
         denops.name,
-        once(denops, (results: unknown) => resolve(results as Candidate[]))[0]
+        once(denops, (results: unknown) => resolve(results as Candidate[]))[0],
       );
     });
 
     // FIXME: Hack: Some LSP (such as Rust Analyzer) sometimes returns
     // candidates ending with whitespace, so fix them here.
     candidates.forEach(
-      (candidate) => (candidate.word = candidate.word.trimEnd())
+      (candidate) => (candidate.word = candidate.word.trimEnd()),
     );
 
     return candidates;

--- a/denops/ddc/sources/ale.ts
+++ b/denops/ddc/sources/ale.ts
@@ -3,20 +3,16 @@
 import {
   BaseSource,
   Candidate,
-  Context,
-  DdcOptions,
-  SourceOptions,
-} from "https://deno.land/x/ddc_vim@v0.0.13/types.ts";
-import { Denops } from "https://deno.land/x/ddc_vim@v0.0.13/deps.ts";
+} from "https://deno.land/x/ddc_vim@v0.3.0/types.ts#^";
+import {
+  GatherCandidatesArguments,
+  GetCompletePositionArguments,
+} from "https://deno.land/x/ddc_vim@v0.3.0/base/source.ts#^";
 import { once } from "https://deno.land/x/denops_std@v1.0.1/anonymous/mod.ts";
 
 export class Source extends BaseSource {
   getCompletePosition(
-    denops: Denops,
-    context: Context,
-    _options: DdcOptions,
-    _sourceOptions: SourceOptions,
-    _sourceParams: Record<string, unknown>
+    { denops, context }: GetCompletePositionArguments,
   ): Promise<number> {
     return denops.call(
       "ale#completion#GetCompletionPositionForDeoplete",
@@ -25,12 +21,7 @@ export class Source extends BaseSource {
   }
 
   async gatherCandidates(
-    denops: Denops,
-    _context: Context,
-    _ddcOptions: DdcOptions,
-    _sourceOptions: SourceOptions,
-    _sourceParams: Record<string, unknown>,
-    _completeStr: string
+    { denops }: GatherCandidatesArguments,
   ): Promise<Candidate[]> {
     const candidates = await new Promise<Candidate[]>((resolve) => {
       denops.call(


### PR DESCRIPTION
Given I find this source to be very valuable, figured I'd give back a bit with a few improvements.

* Update ddc_vim dep
  * The version of ddc_vim used here was quite old, relative to the `release` version, so I bumped the deps and fixed to match new APIs
* Imported some additional types to remove the need for some of manual annotations for `getCompletePosition` and `gatherCandidates`
* Applied `deno fmt` to the changes
  * I realize this could be considered a more controversial change, so I kept it a separate commit in case you'd prefer I don't include it.