### PR TITLE
Refresh Candidates Refactor

### DIFF
--- a/autoload/ddc/ale.vim
+++ b/autoload/ddc/ale.vim
@@ -1,35 +1,16 @@
-let s:plugin_name = v:null
-let s:method_name = v:null
-
 function! s:callback(results) abort
-  if type(s:method_name) == type(v:null)
-    return
-  endif
-
-  if type(a:results) != type([]) && type(a:results) != type(v:null)
+  if type(a:results) != type([])
     let a:results = []
   endif
 
-  " Just in case something might break with the denops call, lets wipe out our
-  " script variables to prevent future timeout errors that could occur
-  let l:plugin_name = s:plugin_name
-  let l:method_name = s:method_name
-  let s:plugin_name = v:null
-  let s:method_name = v:null
-  call denops#notify(l:plugin_name, l:method_name, [a:results])
+  if len(a:results) > 0
+    let g:ddc#source#ale#_results = a:results
+    let g:ddc#source#ale#_requested = v:true
+    call ddc#refresh_candidates()
+  endif
 endfunction
 
-function! ddc#ale#get_completions(plugin_name, method_name) abort
-  " If we were already waiting for a response from the server, we need to go
-  " ahead and call it it with a null value to make room for the next batch of
-  " completions
-  if type(s:method_name) != type(v:null)
-    call s:callback(v:null)
-  endif
-
-  let s:plugin_name = a:plugin_name
-  let s:method_name = a:method_name
-
+function! ddc#ale#get_completions() abort
   if !ale#completion#CanProvideCompletions()
     call s:callback([])
   else

--- a/denops/ddc-sources/ale.ts
+++ b/denops/ddc-sources/ale.ts
@@ -3,42 +3,59 @@
 import {
   BaseSource,
   Candidate,
-} from "https://deno.land/x/ddc_vim@v0.4.3/types.ts";
+} from "https://deno.land/x/ddc_vim@v0.5.2/types.ts";
+import { batch, vars } from "https://deno.land/x/ddc_vim@v0.5.2/deps.ts";
 import {
   GatherCandidatesArguments,
-  GetCompletePositionArguments,
-} from "https://deno.land/x/ddc_vim@v0.4.3/base/source.ts";
-import { once } from "https://deno.land/x/denops_std@v1.8.1/anonymous/mod.ts";
+  OnInitArguments,
+} from "https://deno.land/x/ddc_vim@v0.5.2/base/source.ts";
+
+const DEFAULT_EMPTY_RESULTS: Candidate[] = [];
 
 export class Source extends BaseSource {
-  getCompletePosition(
-    { denops, context }: GetCompletePositionArguments,
-  ): Promise<number> {
-    return denops.call(
-      "ale#completion#GetCompletionPositionForDeoplete",
-      context.input,
-    ) as Promise<number>;
+  async onInit(args: OnInitArguments): Promise<void> {
+    await batch(args.denops, async (denops) => {
+      await vars.g.set(denops, "ddc#source#ale#_results", DEFAULT_EMPTY_RESULTS);
+      await vars.g.set(denops, "ddc#source#ale#_requested", false);
+      await vars.g.set(denops, "ddc#source#ale#_prev_input", "");
+    });
   }
 
   async gatherCandidates(
-    { denops }: GatherCandidatesArguments,
+    args: GatherCandidatesArguments,
   ): Promise<Candidate[]> {
-    return await new Promise<Candidate[]>((resolve) => {
-      denops.call(
-        "ddc#ale#get_completions",
-        denops.name,
-        once(denops, (results: unknown) => {
-          const candidates: Candidate[] = Array.isArray(results) ? results : [];
-          // FIXME: Hack: Some LSP (such as Rust Analyzer) sometimes returns
-          // candidates ending with whitespace, so fix them here.
-          candidates.forEach(
-            (candidate) => {
-              candidate.word = candidate.word.trimEnd();
-            },
-          );
-          resolve(candidates);
-        })[0],
+    const prevInput: string = await vars.g.get(
+      args.denops,
+      "ddc#source#ale#_prev_input",
+    ).then(p => typeof p === 'string' ? p : '');
+    const requested: boolean = await vars.g.get(
+      args.denops,
+      "ddc#source#ale#_requested",
+    ).then(r => typeof r === 'boolean' ? r : false);
+
+    if (args.context.input === prevInput && requested) {
+      const results: Candidate[] = await vars.g.get(
+        args.denops,
+        "ddc#source#ale#_results",
+      ) ?? DEFAULT_EMPTY_RESULTS;
+      // FIXME: Hack: Some LSPs (such as Rust Analyzer) sometimes return
+      // candidates ending with whitespace, so fix them here.
+      results.forEach((result) => result.word = result.word.trimEnd());
+      return results;
+    }
+
+    await batch(args.denops, (denops) => {
+      vars.g.set(denops, "ddc#source#ale#_results", []);
+      vars.g.set(denops, "ddc#source#ale#_requested", false);
+      vars.g.set(
+        denops,
+        "ddc#source#ale#_prev_input",
+        args.context.input,
       );
+      denops.call("ddc#ale#get_completions");
+      return Promise.resolve();
     });
+
+    return [];
   }
 }


### PR DESCRIPTION
As mentioned earlier, this PR refactors the completion to match what I saw from [here](https://github.com/shun/ddc-vim-lsp/blob/main/denops/ddc-sources/ddc-vim-lsp.ts).

TL;DR: Attempt to return as quickly as possible with an empty array, and have the vim code call into `refresh_candidates` when the data has returned.

I took this a bit further, and made the white space trimming a sourceParam. I feel it's something one should only need pay the cost for if they opt in.

I.E. to re-enable the old behavior:

```viml
call ddc#custom#patch_global('sourceParams', {'ale': { 'cleanResultsWhitespace': v:true }})
```

I would've added some documentation for this, but none yet existed.