### PR TITLE
Update deps for latest ddc

### DIFF
--- a/denops/@ddc-sources/ale.ts
+++ b/denops/@ddc-sources/ale.ts
@@ -4,10 +4,10 @@ import {
   BaseSource,
   Item,
   DdcGatherItems
-} from "https://deno.land/x/ddc_vim@v4.1.0/types.ts";
+} from "https://deno.land/x/ddc_vim@v4.3.1/types.ts";
 import {
   GatherArguments,
-} from "https://deno.land/x/ddc_vim@v4.1.0/base/source.ts";
+} from "https://deno.land/x/ddc_vim@v4.3.1/base/source.ts";
 
 type AleParams = {
   cleanResultsWhitespace: boolean;

--- a/denops/@ddc-sources/ale.ts
+++ b/denops/@ddc-sources/ale.ts
@@ -4,10 +4,10 @@ import {
   BaseSource,
   Item,
   DdcGatherItems
-} from "https://deno.land/x/ddc_vim@v2.3.0/types.ts";
+} from "https://deno.land/x/ddc_vim@v4.1.0/types.ts";
 import {
   GatherArguments,
-} from "https://deno.land/x/ddc_vim@v2.3.0/base/source.ts";
+} from "https://deno.land/x/ddc_vim@v4.1.0/base/source.ts";
 
 type AleParams = {
   cleanResultsWhitespace: boolean;


### PR DESCRIPTION
Looks like a recent deprecation in DDC broke the autocompletion with ddc-ale.

Seems a version bump fixes this